### PR TITLE
machines: set up package server provisioning

### DIFF
--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -10,7 +10,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 5.0"
+      version = "= 5.8.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -16,9 +16,6 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 4.31"
     }
-    equinix = {
-      source = "equinix/equinix"
-    }
   }
   backend "remote" {
     organization = "calyptia"

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -16,6 +16,9 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 4.31"
     }
+    equinix = {
+      source = "equinix/equinix"
+    }
   }
   backend "remote" {
     organization = "calyptia"

--- a/terraform/domains.tf
+++ b/terraform/domains.tf
@@ -4,22 +4,6 @@ data "cloudflare_zones" "fluentbit-io-zone" {
   }
 }
 
-resource "cloudflare_record" "builder" {
-  name    = "builder"
-  value   = data.metal_device.builder.access_public_ipv4
-  type    = "A"
-  proxied = false
-  zone_id = lookup(data.cloudflare_zones.fluentbit-io-zone.zones[0], "id")
-}
-
-resource "cloudflare_record" "dev-arm" {
-  name    = "dev-arm"
-  value   = data.metal_device.dev-arm.access_public_ipv4
-  type    = "A"
-  proxied = false
-  zone_id = lookup(data.cloudflare_zones.fluentbit-io-zone.zones[0], "id")
-}
-
 resource "cloudflare_record" "www" {
   name    = "www"
   value   = "stoic-goldberg-e3a26b.netlify.app"
@@ -33,14 +17,6 @@ resource "cloudflare_record" "root-www" {
   value   = "apex-loadbalancer.netlify.com"
   type    = "CNAME"
   proxied = true
-  zone_id = lookup(data.cloudflare_zones.fluentbit-io-zone.zones[0], "id")
-}
-
-resource "cloudflare_record" "perf-test" {
-  name    = "perf-test"
-  value   = data.metal_device.perf-test.access_public_ipv4
-  type    = "A"
-  proxied = false
   zone_id = lookup(data.cloudflare_zones.fluentbit-io-zone.zones[0], "id")
 }
 

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -36,25 +36,25 @@ locals {
     "1.8",
   ]
 }
-resource "github_branch_protection_v3" "default-branch-protection" {
-  repository = data.github_repository.fluentbit.name
+# resource "github_branch_protection_v3" "default-branch-protection" {
+#   repository = data.github_repository.fluentbit.name
 
-  for_each = toset(local.fluent_bit_protected_branches)
-  branch   = each.value
+#   for_each = toset(local.fluent_bit_protected_branches)
+#   branch   = each.value
 
-  enforce_admins = false
+#   enforce_admins = false
 
-  required_pull_request_reviews {
-    dismiss_stale_reviews           = true
-    require_code_owner_reviews      = true
-    required_approving_review_count = 1
-  }
+#   required_pull_request_reviews {
+#     dismiss_stale_reviews           = true
+#     require_code_owner_reviews      = true
+#     required_approving_review_count = 1
+#   }
 
-  required_status_checks {
-    strict   = false
-    contexts = ["Unit tests (matrix)", "Check Commit Message"]
-  }
-}
+#   required_status_checks {
+#     strict   = false
+#     contexts = ["Unit tests (matrix)", "Check Commit Message"]
+#   }
+# }
 
 data "github_user" "release-approvers-users" {
   for_each = var.release-approvers-usernames
@@ -270,17 +270,17 @@ resource "github_repository" "fluent-bit-unstable-releases" {
 }
 
 # No one should be merging
-resource "github_branch_protection_v3" "fluent-bit-unstable-releases" {
-  repository     = github_repository.fluent-bit-unstable-releases.name
-  branch         = "main"
-  enforce_admins = false
+# resource "github_branch_protection_v3" "fluent-bit-unstable-releases" {
+#   repository     = github_repository.fluent-bit-unstable-releases.name
+#   branch         = "main"
+#   enforce_admins = false
 
-  restrictions {
-    users = []
-    teams = []
-    apps  = []
-  }
-}
+#   restrictions {
+#     users = []
+#     teams = []
+#     apps  = []
+#   }
+# }
 
 resource "github_repository_environment" "unstable-environment" {
   environment = "unstable"
@@ -357,21 +357,21 @@ resource "github_repository" "fluent-bit-sandbox" {
   license_template       = "apache-2.0"
 }
 
-resource "github_branch_protection_v3" "fluent-bit-sandbox" {
-  repository     = github_repository.fluent-bit-sandbox.name
-  branch         = "main"
-  enforce_admins = false
+# resource "github_branch_protection_v3" "fluent-bit-sandbox" {
+#   repository     = github_repository.fluent-bit-sandbox.name
+#   branch         = "main"
+#   enforce_admins = false
 
-  required_pull_request_reviews {
-    dismiss_stale_reviews           = true
-    require_code_owner_reviews      = true
-    required_approving_review_count = 1
-  }
+#   required_pull_request_reviews {
+#     dismiss_stale_reviews           = true
+#     require_code_owner_reviews      = true
+#     required_approving_review_count = 1
+#   }
 
-  restrictions {
-    teams = [github_team.fluent-bit-sandbox-maintainers.slug]
-  }
-}
+#   restrictions {
+#     teams = [github_team.fluent-bit-sandbox-maintainers.slug]
+#   }
+# }
 
 resource "github_team_repository" "fluent-bit-sandbox-maintainers" {
   team_id    = github_team.fluent-bit-sandbox-maintainers.id

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -36,25 +36,25 @@ locals {
     "1.8",
   ]
 }
-# resource "github_branch_protection_v3" "default-branch-protection" {
-#   repository = data.github_repository.fluentbit.name
+resource "github_branch_protection_v3" "default-branch-protection" {
+  repository = data.github_repository.fluentbit.name
 
-#   for_each = toset(local.fluent_bit_protected_branches)
-#   branch   = each.value
+  for_each = toset(local.fluent_bit_protected_branches)
+  branch   = each.value
 
-#   enforce_admins = false
+  enforce_admins = false
 
-#   required_pull_request_reviews {
-#     dismiss_stale_reviews           = true
-#     require_code_owner_reviews      = true
-#     required_approving_review_count = 1
-#   }
+  required_pull_request_reviews {
+    dismiss_stale_reviews           = true
+    require_code_owner_reviews      = true
+    required_approving_review_count = 1
+  }
 
-#   required_status_checks {
-#     strict   = false
-#     contexts = ["Unit tests (matrix)", "Check Commit Message"]
-#   }
-# }
+  required_status_checks {
+    strict   = false
+    contexts = ["Unit tests (matrix)", "Check Commit Message"]
+  }
+}
 
 data "github_user" "release-approvers-users" {
   for_each = var.release-approvers-usernames
@@ -270,17 +270,17 @@ resource "github_repository" "fluent-bit-unstable-releases" {
 }
 
 # No one should be merging
-# resource "github_branch_protection_v3" "fluent-bit-unstable-releases" {
-#   repository     = github_repository.fluent-bit-unstable-releases.name
-#   branch         = "main"
-#   enforce_admins = false
+resource "github_branch_protection_v3" "fluent-bit-unstable-releases" {
+  repository     = github_repository.fluent-bit-unstable-releases.name
+  branch         = "main"
+  enforce_admins = false
 
-#   restrictions {
-#     users = []
-#     teams = []
-#     apps  = []
-#   }
-# }
+  restrictions {
+    users = []
+    teams = []
+    apps  = []
+  }
+}
 
 resource "github_repository_environment" "unstable-environment" {
   environment = "unstable"
@@ -357,21 +357,21 @@ resource "github_repository" "fluent-bit-sandbox" {
   license_template       = "apache-2.0"
 }
 
-# resource "github_branch_protection_v3" "fluent-bit-sandbox" {
-#   repository     = github_repository.fluent-bit-sandbox.name
-#   branch         = "main"
-#   enforce_admins = false
+resource "github_branch_protection_v3" "fluent-bit-sandbox" {
+  repository     = github_repository.fluent-bit-sandbox.name
+  branch         = "main"
+  enforce_admins = false
 
-#   required_pull_request_reviews {
-#     dismiss_stale_reviews           = true
-#     require_code_owner_reviews      = true
-#     required_approving_review_count = 1
-#   }
+  required_pull_request_reviews {
+    dismiss_stale_reviews           = true
+    require_code_owner_reviews      = true
+    required_approving_review_count = 1
+  }
 
-#   restrictions {
-#     teams = [github_team.fluent-bit-sandbox-maintainers.slug]
-#   }
-# }
+  restrictions {
+    teams = [github_team.fluent-bit-sandbox-maintainers.slug]
+  }
+}
 
 resource "github_team_repository" "fluent-bit-sandbox-maintainers" {
   team_id    = github_team.fluent-bit-sandbox-maintainers.id

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -31,7 +31,7 @@ resource "github_branch_default" "mirror-default-branch" {
 # We only want this for the normal Fluent Bit repository.
 locals {
   fluent_bit_protected_branches = [
-    data.github_repository.fluentbit.default_branch,
+    "master",
     "1.9",
     "1.8",
   ]
@@ -269,20 +269,10 @@ resource "github_repository" "fluent-bit-unstable-releases" {
   license_template       = "apache-2.0"
 }
 
-resource "github_branch" "fluent-bit-unstable-releases" {
-  repository = github_repository.fluent-bit-unstable-releases.name
-  branch     = "main"
-}
-
-resource "github_branch_default" "fluent-bit-unstable-releases" {
-  repository = github_repository.fluent-bit-unstable-releases.name
-  branch     = github_branch.fluent-bit-unstable-releases.branch
-}
-
 # No one should be merging
 resource "github_branch_protection_v3" "fluent-bit-unstable-releases" {
   repository     = github_repository.fluent-bit-unstable-releases.name
-  branch         = github_branch.fluent-bit-unstable-releases.branch
+  branch         = "main"
   enforce_admins = false
 
   restrictions {
@@ -367,19 +357,9 @@ resource "github_repository" "fluent-bit-sandbox" {
   license_template       = "apache-2.0"
 }
 
-resource "github_branch" "fluent-bit-sandbox" {
-  repository = github_repository.fluent-bit-sandbox.name
-  branch     = "main"
-}
-
-resource "github_branch_default" "fluent-bit-sandbox" {
-  repository = github_repository.fluent-bit-sandbox.name
-  branch     = github_branch.fluent-bit-sandbox.branch
-}
-
 resource "github_branch_protection_v3" "fluent-bit-sandbox" {
   repository     = github_repository.fluent-bit-sandbox.name
-  branch         = github_branch.fluent-bit-sandbox.branch
+  branch         = "main"
   enforce_admins = false
 
   required_pull_request_reviews {

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -269,10 +269,20 @@ resource "github_repository" "fluent-bit-unstable-releases" {
   license_template       = "apache-2.0"
 }
 
+resource "github_branch" "fluent-bit-unstable-releases" {
+  repository = github_repository.fluent-bit-unstable-releases.name
+  branch     = "main"
+}
+
+resource "github_branch_default" "fluent-bit-unstable-releases" {
+  repository = github_repository.fluent-bit-unstable-releases.name
+  branch     = github_branch.fluent-bit-unstable-releases.branch
+}
+
 # No one should be merging
 resource "github_branch_protection_v3" "fluent-bit-unstable-releases" {
   repository     = github_repository.fluent-bit-unstable-releases.name
-  branch         = github_repository.fluent-bit-unstable-releases.default_branch
+  branch         = github_branch.fluent-bit-unstable-releases.branch
   enforce_admins = false
 
   restrictions {
@@ -357,9 +367,19 @@ resource "github_repository" "fluent-bit-sandbox" {
   license_template       = "apache-2.0"
 }
 
+resource "github_branch" "fluent-bit-sandbox" {
+  repository = github_repository.fluent-bit-sandbox.name
+  branch     = "main"
+}
+
+resource "github_branch_default" "fluent-bit-sandbox" {
+  repository = github_repository.fluent-bit-sandbox.name
+  branch     = github_branch.fluent-bit-sandbox.branch
+}
+
 resource "github_branch_protection_v3" "fluent-bit-sandbox" {
   repository     = github_repository.fluent-bit-sandbox.name
-  branch         = github_repository.fluent-bit-sandbox.default_branch
+  branch         = github_branch.fluent-bit-sandbox.branch
   enforce_admins = false
 
   required_pull_request_reviews {

--- a/terraform/machines.tf
+++ b/terraform/machines.tf
@@ -276,15 +276,15 @@ resource "metal_device" "packages-fluent-bit" {
   }
 
   # Set up packages to install
-  #   user_data = <<EOS
-  # #cloud-config
-  # package_update: true
-  # packages:
-  #   - docker.io
-  #   - nginx
-  #   - awscli
-  #   - git
-  # EOS
+  user_data = <<EOS
+#cloud-config
+package_update: true
+packages:
+  - docker.io
+  - nginx
+  - awscli
+  - git
+EOS
 }
 
 resource "null_resource" "packages-fluent-bit-provision" {

--- a/terraform/machines.tf
+++ b/terraform/machines.tf
@@ -293,13 +293,11 @@ resource "null_resource" "packages-fluent-bit-provision" {
     metal_ssh_key.packages-fluent-bit-provision-ssh-pub-key,
     metal_device.packages-fluent-bit,
   ]
-  triggers = {
-    public_ip   = metal_device.packages-fluent-bit.access_public_ipv4
-    private_key = chomp(metal_ssh_key.packages-fluent-bit-provision-ssh-pub-key)
-  }
+
   connection {
-    host        = self.triggers.public_ip
-    private_key = self.triggers.private_key
+    type        = "ssh"
+    host        = metal_device.packages-fluent-bit.access_public_ipv4
+    private_key = chomp(metal_ssh_key.packages-fluent-bit-provision-ssh-pub-key)
   }
 
   provisioner "file" {

--- a/terraform/machines.tf
+++ b/terraform/machines.tf
@@ -257,12 +257,12 @@ resource "tls_private_key" "packages-fluent-bit-provision-key" {
   rsa_bits  = 4096
 }
 
-resource "equinix_metal_ssh_key" "packages-fluent-bit-provision-ssh-pub-key" {
+resource "metal_ssh_key" "packages-fluent-bit-provision-ssh-pub-key" {
   name       = "packages-fluent-bit-provision-ssh-pub-key"
   public_key = chomp(tls_private_key.packages-fluent-bit-provision-key.public_key_openssh)
 }
 
-resource "equinix_metal_device" "packages-fluent-bit" {
+resource "metal_device" "packages-fluent-bit" {
   hostname         = "packages-managed.fluentbit.io"
   plan             = "c3.small.x86"
   metro            = "da"
@@ -278,7 +278,7 @@ packages:
   - awscli
   - git
 EOF
-  depends_on       = [equinix_metal_ssh_key.packages-fluent-bit-provision-ssh-pub-key]
+  depends_on       = [metal_ssh_key.packages-fluent-bit-provision-ssh-pub-key]
   connection {
     host     = self.access_public_ipv4
     password = self.root_password
@@ -288,12 +288,12 @@ EOF
 resource "null_resource" "packages-fluent-bit-provision" {
 
   depends_on = [
-    equinix_metal_ssh_key.packages-fluent-bit-provision-ssh-pub-key,
-    equinix_metal_device.packages-fluent-bit,
+    metal_ssh_key.packages-fluent-bit-provision-ssh-pub-key,
+    metal_device.packages-fluent-bit,
   ]
   triggers = {
-    public_ip   = equinix_metal_device.packages-fluent-bit.access_public_ipv4
-    private_key = chomp(equinix_metal_ssh_key.packages-fluent-bit-provision-ssh-pub-key)
+    public_ip   = metal_device.packages-fluent-bit.access_public_ipv4
+    private_key = chomp(metal_ssh_key.packages-fluent-bit-provision-ssh-pub-key)
   }
   connection {
     host        = self.triggers.public_ip

--- a/terraform/machines.tf
+++ b/terraform/machines.tf
@@ -263,26 +263,28 @@ resource "metal_ssh_key" "packages-fluent-bit-provision-ssh-pub-key" {
 }
 
 resource "metal_device" "packages-fluent-bit" {
+  depends_on       = [metal_ssh_key.packages-fluent-bit-provision-ssh-pub-key]
   hostname         = "packages-managed.fluentbit.io"
   plan             = "c3.small.x86"
   metro            = "da"
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
-  user_data        = <<EOF
-#cloud-config
-package_update: true
-packages:
-  - docker.io
-  - nginx
-  - awscli
-  - git
-EOF
-  depends_on       = [metal_ssh_key.packages-fluent-bit-provision-ssh-pub-key]
   connection {
     host     = self.access_public_ipv4
     password = self.root_password
   }
+
+  # Set up packages to install
+  #   user_data = <<EOS
+  # #cloud-config
+  # package_update: true
+  # packages:
+  #   - docker.io
+  #   - nginx
+  #   - awscli
+  #   - git
+  # EOS
 }
 
 resource "null_resource" "packages-fluent-bit-provision" {

--- a/terraform/provision/package-server-provision.sh
+++ b/terraform/provision/package-server-provision.sh
@@ -61,8 +61,8 @@ systemctl restart nginx
 #     ufw status
 # fi
 
-# Set up sync
-aws s3 sync s3://fluentbit-releases /var/www/apt.fluentbit.io --no-sign-request
+# Sync now - move to the job
+# aws s3 sync s3://fluentbit-releases /var/www/apt.fluentbit.io --no-sign-request
 
 # Set up cron job
 cat > /etc/systemd/system/packages-sync.service <<EOF

--- a/terraform/provision/package-server-provision.sh
+++ b/terraform/provision/package-server-provision.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+set -eu
+mkdir -p /var/www/apt.fluentbit.io /var/www/releases.fluentbit.io
+
+# TODO: certificates from certbot
+
+# Set up the package serving
+cat > /etc/nginx/sites-available/apt.fluentbit.io <<'EOF'
+server {
+
+	root /var/www/apt.fluentbit.io;
+	index index.html index.htm index.nginx-debian.html;
+
+	server_name apt.fluentbit.io packages.fluentbit.io;
+	access_log /var/log/nginx/apt.fluentbit.io.access.log;
+	error_log  /var/log/nginx/apt.fluentbit.io.error.log;
+
+	location / {
+		try_files $uri $uri/ =404;
+		autoindex on;
+	}
+
+    listen [::]:443 ssl; # managed by Certbot
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/packages.fluentbit.io/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/packages.fluentbit.io/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+
+}
+server {
+    if ($host = packages.fluentbit.io) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+    if ($host = apt.fluentbit.io) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+	listen 80;
+	listen [::]:80;
+
+	server_name apt.fluentbit.io packages.fluentbit.io;
+    return 404; # managed by Certbot
+
+}
+EOF
+ln -s /etc/nginx/sites-available/apt-fluentbit.io /etc/nginx/sites-enabled/apt-fluentbit.io
+
+# Set up the releases handling - Windows + Source/JSON
+cat > /etc/nginx/sites-available/releases.fluentbit.io <<'EOF'
+server {
+
+	root /var/www/releases.fluentbit.io/releases;
+	index index.html index.htm index.nginx-debian.html;
+
+	server_name releases.fluentbit.io;
+	access_log /var/log/nginx/releases.fluentbit.io.access.log;
+	error_log  /var/log/nginx/releases.fluentbit.io.error.log;
+
+	location / {
+		try_files $uri $uri/ =404;
+                autoindex on;
+	}
+
+    listen [::]:443 ssl; # managed by Certbot
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/fluentbit.io/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/fluentbit.io/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+}
+server {
+    if ($host = releases.fluentbit.io) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+	listen 80;
+	listen [::]:80;
+
+	server_name releases.fluentbit.io;
+    return 404; # managed by Certbot
+
+}
+EOF
+ln -s /etc/nginx/sites-available/releases-fluentbit.io /etc/nginx/sites-enabled/releases-fluentbit.io
+
+# Need to set up certbot
+# snap install core
+# snap refresh core
+# snap install --classic certbot
+# ln -s /snap/bin/certbot /usr/bin/certbot
+# certbot --nginx
+
+systemctl restart nginx
+
+# Set up sync
+aws s3 sync s3://fluentbit-releases /var/www/apt.fluentbit.io --no-sign-request
+
+# Set up cron job
+cat > /etc/systemd/system/packages-sync.service <<EOF
+[Unit]
+Description=Syncs all release packages from the AWS bucket to this server.
+Wants=packages-sync.timer
+
+[Service]
+Type=oneshot
+ExecStart=aws s3 sync s3://fluentbit-releases /var/www/apt.fluentbit.io --no-sign-request
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > /etc/systemd/system/packages-sync.timer <<EOF
+[Unit]
+Description=Syncs all release packages from the AWS bucket to this server.
+Requires=packages-sync.service
+
+[Timer]
+Unit=packages-sync.service
+OnCalendar=*-*-* *:00:00
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now packages-sync.timer
+
+mkdir -p /opt/fluent-bit-stats
+git clone https://github.com/niedbalski/fluent-bit-stats.git /opt/fluent-bit-stats
+pushd /opt/fluent-bit-stats
+    docker compose up -d 
+popd


### PR DESCRIPTION
Current packages server is EOL and is not managed via automation.
This creates a bare metal machine in Equinix, sets up the various packages we need and syncs from the release bucket. At least as a POC initially for further iteration.

Intention is we can run this anytime to create a new server but we would manually "promote" it to the official one.

Discovered an issue with the Github provider not parsing the branch protection information when it refreshes correctly so fixed it to 5.8.0 which seems to work ok.

TODO:
- Windows packages from AppVeyor
- Handle Certbot deployment
- Source packages