### PR TITLE
domains: add new domains for IaC package server testing

### DIFF
--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -9,8 +9,9 @@ terraform {
       version = "~> 3.21"
     }
     github = {
-      source  = "integrations/github"
-      version = "5.12.0"
+      source = "integrations/github"
+      # We need lock_branch fixes from 5.12
+      version = ">= 5.12.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/terraform/domains.tf
+++ b/terraform/domains.tf
@@ -165,3 +165,36 @@ resource "cloudflare_record" "short-registry" {
   proxied = false
   zone_id = lookup(data.cloudflare_zones.fluentbit-io-zone.zones[0], "id")
 }
+
+resource "cloudflare_record" "releases-next" {
+  name    = "releases-next"
+  value   = metal_device.packages-fluent-bit.access_public_ipv4
+  type    = "A"
+  proxied = true
+  zone_id = lookup(data.cloudflare_zones.fluentbit-io-zone.zones[0], "id")
+}
+
+resource "cloudflare_record" "packages-next" {
+  name    = "packages-next"
+  value   = metal_device.packages-fluent-bit.access_public_ipv4
+  type    = "A"
+  proxied = true
+  zone_id = lookup(data.cloudflare_zones.fluentbit-io-zone.zones[0], "id")
+}
+
+resource "cloudflare_record" "apt-next" {
+  name    = "apt-next"
+  value   = metal_device.packages-fluent-bit.access_public_ipv4
+  type    = "A"
+  proxied = true
+  zone_id = lookup(data.cloudflare_zones.fluentbit-io-zone.zones[0], "id")
+}
+
+resource "cloudflare_record" "packages-s3-mirror" {
+  name    = "packages-mirror"
+  value   = "fluentbit-releases.s3.amazonaws.com"
+  type    = "CNAME"
+  proxied = true
+  zone_id = lookup(data.cloudflare_zones.fluentbit-io-zone.zones[0], "id")
+}
+

--- a/terraform/provision/package-server-provision.sh.tftpl
+++ b/terraform/provision/package-server-provision.sh.tftpl
@@ -154,6 +154,8 @@ certbot certonly -n --agree-tos --email 'ci@calyptia.com' \
 	--dns-cloudflare \
 	--dns-cloudflare-credentials /root/.secrets/certbot/cloudflare.ini \
 	--dns-cloudflare-propagation-seconds 60 \
+	-d apt-next.fluentbit.io \
+	-d www.apt-next.fluentbit.io \
 	-d packages-next.fluentbit.io \
 	-d www.packages-next.fluentbit.io \
 	-d releases-next.fluentbit.io \
@@ -161,6 +163,8 @@ certbot certonly -n --agree-tos --email 'ci@calyptia.com' \
 
 # Now configure Nginx to use the certificates we got above.
 certbot --nginx -n --agree-tos --email 'ci@calyptia.com' \
+	-d apt-next.fluentbit.io \
+	-d www.apt-next.fluentbit.io \
 	-d packages-next.fluentbit.io \
 	-d www.packages-next.fluentbit.io \
 	-d releases-next.fluentbit.io \


### PR DESCRIPTION
Add domains to point at the package server we are automatically managing now:
- apt-next.fluentbit.io
- packages-next.fluentbit.io
- releases-next.fluentbit.io

We also add a `packages-mirror.fluentbit.io` backup domain for the S3 bucket we use for releases (and that the server syncs from).