### PR TITLE
urls: set up redirect for releases-next

### DIFF
--- a/.github/actions/terraform-setup/action.yml
+++ b/.github/actions/terraform-setup/action.yml
@@ -180,7 +180,7 @@ runs:
         exit $exitCode
       shell: bash
 
-    - uses: hashicorp/setup-terraform@v1
+    - uses: hashicorp/setup-terraform@v2
       with:
         cli_config_credentials_hostname: ${{ inputs.terraform-api-host }}
         cli_config_credentials_token: ${{ inputs.terraform_cloud_api_token }}

--- a/terraform/urls.tf
+++ b/terraform/urls.tf
@@ -40,7 +40,7 @@ resource "cloudflare_page_rule" "releases-fluentbitio" {
   }
 }
 
-resource "cloudflare_page_rule" "releases-fluentbitio" {
+resource "cloudflare_page_rule" "releases-next-fluentbitio" {
   zone_id  = lookup(data.cloudflare_zones.fluentbit-io-zone.zones[0], "id")
   target   = "https://${var.cloudflare_domain}/releases-next/*"
   priority = 4

--- a/terraform/urls.tf
+++ b/terraform/urls.tf
@@ -26,7 +26,7 @@ resource "cloudflare_page_rule" "downloads-fluentbitio" {
   }
 }
 
-# For legacy releases, forward the download URL to the old server
+# For source and windows releases, forward the download URL to the server
 resource "cloudflare_page_rule" "releases-fluentbitio" {
   zone_id  = lookup(data.cloudflare_zones.fluentbit-io-zone.zones[0], "id")
   target   = "https://${var.cloudflare_domain}/releases/*"
@@ -35,6 +35,19 @@ resource "cloudflare_page_rule" "releases-fluentbitio" {
   actions {
     forwarding_url {
       url         = "https://releases.${var.cloudflare_domain}/$1"
+      status_code = 301
+    }
+  }
+}
+
+resource "cloudflare_page_rule" "releases-fluentbitio" {
+  zone_id  = lookup(data.cloudflare_zones.fluentbit-io-zone.zones[0], "id")
+  target   = "https://${var.cloudflare_domain}/releases-next/*"
+  priority = 4
+
+  actions {
+    forwarding_url {
+      url         = "https://releases-next.${var.cloudflare_domain}/$1"
       status_code = 301
     }
   }


### PR DESCRIPTION
Set up redirect to simplify testing.
Looks like dependabot cannot cope with composite actions so manually updated the action version.

Signed-off-by: Patrick Stephens <pat@calyptia.com>